### PR TITLE
fix: remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.2.2"
   },
-  "peerDependencies": {
-    "@chainsafe/hashtree-darwin-arm64": "1.0.0",
-    "@chainsafe/hashtree-linux-x64-gnu": "1.0.0",
-    "@chainsafe/hashtree-linux-arm64-gnu": "1.0.0"
-  },
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {


### PR DESCRIPTION
napi-rs will automatically add optionalDependencies for all supported triples, see https://napi.rs/docs/cli/pre-publish