### PR TITLE
chore: update hashtree to latest upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hashtree"]
 	path = hashtree
-	url = https://github.com/matthewkeil/hashtree.git
+	url = https://github.com/offchainlabs/hashtree.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ARG NODE_VERSION
 
-FROM ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
+FROM ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-aarch64
 
 COPY . /usr/src/hashtree-js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ARG NODE_VERSION
 
-FROM ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-aarch64
+FROM ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
 
 COPY . /usr/src/hashtree-js
 


### PR DESCRIPTION
- latest upstream includes a fallback sha implementation (meaning we can avoid https://github.com/ChainSafe/hashtree-js/pull/17)