### PR TITLE
chore: bump node and enable trusted publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,9 @@
 name: CI
 permissions:
-  contents: write
-  id-token: write
+  contents: write # Required for OIDC
+  id-token: write # Required to create a Github release
+  pull-requests: write # Required to add tags to pull requests
+
 env:
   DEBUG: napi:*
   APP_NAME: hashtree-js
@@ -26,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Setup Core pack 
         run: corepack enable
       - name: Install
@@ -91,7 +93,7 @@ jobs:
           # - host: ubuntu-latest
           #   target: wasm32-wasip1-threads
           #   build: yarn build --target wasm32-wasip1-threads
-    name: stable - ${{ matrix.settings.target }} - node@24
+    name: stable - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v5
@@ -100,7 +102,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Setup Core pack 
         run: corepack enable          
       - name: Install
@@ -167,8 +169,8 @@ jobs:
           #   target: aarch64-pc-windows-msvc
           #   architecture: arm64
         node:
+          - '20'
           - '22'
-          - '24'
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v5
@@ -206,8 +208,8 @@ jobs:
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
         node:
+          - '20'
           - '22'
-          - '24'
     runs-on: ${{ contains(matrix.target, 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
@@ -282,7 +284,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Upgrade npm for OIDC
         run: npm i -g npm@^11.5.1
       - name: Setup Core pack 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Setup Core pack 
         run: corepack enable
       - name: Install
@@ -91,7 +91,7 @@ jobs:
           # - host: ubuntu-latest
           #   target: wasm32-wasip1-threads
           #   build: yarn build --target wasm32-wasip1-threads
-    name: stable - ${{ matrix.settings.target }} - node@22
+    name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v5
@@ -100,7 +100,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Setup Core pack 
         run: corepack enable          
       - name: Install
@@ -167,8 +167,8 @@ jobs:
           #   target: aarch64-pc-windows-msvc
           #   architecture: arm64
         node:
-          - '20'
           - '22'
+          - '24'
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v5
@@ -206,8 +206,8 @@ jobs:
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
         node:
-          - '20'
           - '22'
+          - '24'
     runs-on: ${{ contains(matrix.target, 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
@@ -282,7 +282,9 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+      - name: Upgrade npm for OIDC
+        run: npm i -g npm@^11.5.1
       - name: Setup Core pack 
         run: corepack enable
       - name: Install dependencies
@@ -300,9 +302,6 @@ jobs:
         shell: bash
       - name: Publish
         run: |
-          npm config set provenance true
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           npm publish --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR bumps node from 22 to 24 and enables trusted publishing for NPM.